### PR TITLE
fix guest user problem

### DIFF
--- a/force-app/main/default/classes/userProfileController.cls
+++ b/force-app/main/default/classes/userProfileController.cls
@@ -1,6 +1,9 @@
 public with sharing class userProfileController {
     @AuraEnabled
     public static Map<String,Object> getUserProfile() {
+        if (userinfo.getUserType() == 'Guest') {
+            return new Map<String,Object>{};
+        }
         if (!Schema.sObjectType.Profile.fields.Id.isAccessible() || !Schema.sObjectType.Profile.fields.Name.isAccessible()) {
             throw new System.NoAccessException();
         }


### PR DESCRIPTION
I noticed that when I tried viewing my component as a guest user in my digital experience, it was throwing an error because I don't have access to the name and id fields in the DB. (I already have given the guest user access to the apex class, it's just in the apex class itself that there's an error)

I think that a simple workaround is to just return right away when then user type is `Guest`. It fixes the bug but I don't know if it's a good practice, so please let me know 👍 